### PR TITLE
fix: corregir expresión lambda para filtros

### DIFF
--- a/Extensions/DynamicFilterExtensions.cs
+++ b/Extensions/DynamicFilterExtensions.cs
@@ -22,6 +22,10 @@
             // Iteramos todas las propiedades públicas del objeto recibido
             foreach (PropertyInfo prop in parametros.GetType().GetProperties())
             {
+                // Si la propiedad se llama "Id" (ignorar mayúsculas/minúsculas), se omite
+                if (string.Equals(prop.Name, "Id", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 // Obtenemos el valor actual de la propiedad
                 var value = prop.GetValue(parametros);
 


### PR DESCRIPTION
Se soluciona el error de la construcción de las expresiones lambda para que no tenga en cuenta la propiedad por defecto de la entidad base